### PR TITLE
clang-tidy fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,23 +18,65 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
-      - name: Install dependencies
+
+      - name: Install dependencies (linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq
-          sudo apt install libfmt-dev python3-pybind11
-      - name: Install dependencies
+          sudo apt install lcov libfmt-dev python3-pybind11
+
+      - name: Install dependencies (macos)
         if: startsWith(matrix.os, 'macos')
-        run: brew install cmake llvm@12 fmt pybind11
+        run: brew install cmake llvm@14 lcov fmt pybind11
+
       - name: Install python dependencies
         run: |
           python3 -m pip install --upgrade pip
           pip3 install flake8 pytest
+
+      - name: Set up env (macos)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          echo "$(brew --cellar)/llvm@14/14.0.6/bin" >> $GITHUB_PATH
+
       - name: Configure
         run: |
           cmake -S . -B ${{ github.workspace }}/build \
-            -DFPROPS_BUILD_TESTS=YES
+            -DFPROPS_BUILD_TESTS=YES \
+            -DFPROPS_CODE_COVERAGE=YES
+
       - name: Build
         run: make -C ${{ github.workspace }}/build
+
       - name: Run tests
         run: make -C ${{ github.workspace }}/build test ARGS='-V'
+
+      - name: Generate code coverage
+        if: startsWith(matrix.os, 'ubuntu')
+        run: make -C ${{ github.workspace }}/build coverage
+
+      - name: Upload coverage artifact
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-${{ matrix.os }}
+          path: ${{ github.workspace }}/build/coverage.info
+
+  upload-to-codecov:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: 'coverage-ubuntu-22.04/coverage.info'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,5 +17,5 @@ jobs:
     - name: Clang-format style check
       uses: jidicula/clang-format-action@v4.3.0
       with:
-        clang-format-version: '13'
+        clang-format-version: '14'
         check-path: .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 include(FetchContent)
+include(${CMAKE_SOURCE_DIR}/cmake/CodeCoverage.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/Sanitization.cmake)
 
 option(FPROPS_WITH_PYTHON "Build python wrapper" YES)
 option(FPROPS_BUILD_TESTS "Build tests" NO)

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,170 @@
+
+option(FPROPS_CODE_COVERAGE "Builds targets with code coverage instrumentation" OFF)
+
+if(FPROPS_CODE_COVERAGE)
+
+    set(COVERAGE_INFO ${PROJECT_BINARY_DIR}/coverage.info)
+    mark_as_advanced(FORCE COVERAGE_INFO)
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${COVERAGE_INFO}")
+
+    if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+        find_program(
+            LLVM_COV_PATH
+            NAMES
+                llvm-cov
+        )
+        find_program(
+            LLVM_PROFDATA_PATH
+            NAMES
+                llvm-profdata
+        )
+        mark_as_advanced(FORCE LLVM_COV_PATH LLVM_PROFDATA_PATH)
+
+        set(CODE_COVERAGE_PROFRAWS ${CMAKE_BINARY_DIR}/test/fprops-test.profraw)
+        set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CODE_COVERAGE_PROFRAWS}")
+
+        set(EXCLUDE_REGEX
+        )
+
+        set(CODE_COVERAGE_BINS
+            --object=${PROJECT_BINARY_DIR}/src/libfprops${CMAKE_SHARED_LIBRARY_SUFFIX}
+        )
+
+        set(MERGED_PROFDATA ${PROJECT_BINARY_DIR}/all-merged.profdata)
+
+
+        add_custom_target(coverage DEPENDS ${COVERAGE_INFO})
+
+        add_custom_command(
+            OUTPUT
+                ${COVERAGE_INFO}
+            COMMAND
+                ${LLVM_COV_PATH}
+                export
+                ${CODE_COVERAGE_BINS}
+                -instr-profile=${MERGED_PROFDATA}
+                -format="lcov"
+                ${EXCLUDE_REGEX}
+                > ${COVERAGE_INFO}
+            DEPENDS
+                ${MERGED_PROFDATA}
+        )
+
+        add_custom_command(
+            OUTPUT
+                ${MERGED_PROFDATA}
+            COMMAND
+                ${LLVM_PROFDATA_PATH}
+                merge
+                -sparse
+                ${CODE_COVERAGE_PROFRAWS}
+                -o ${MERGED_PROFDATA}
+            DEPENDS
+                ${CODE_COVERAGE_PROFRAWS}
+        )
+
+        add_custom_target(htmlcov DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html)
+        add_custom_command(
+            OUTPUT
+                ${PROJECT_BINARY_DIR}/htmlcov/index.html
+            COMMAND
+                ${LLVM_COV_PATH}
+                show
+                ${CODE_COVERAGE_BINS}
+                -instr-profile=${MERGED_PROFDATA}
+                -show-line-counts-or-regions
+                -output-dir=${CMAKE_BINARY_DIR}/htmlcov
+                -format="html"
+                ${EXCLUDE_REGEX}
+            DEPENDS
+                ${COVERAGE_INFO}
+        )
+
+        add_custom_command(
+            TARGET htmlcov
+            POST_BUILD
+            COMMAND ;
+            COMMENT
+                "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
+        )
+
+        function(target_code_coverage TARGET_NAME)
+            target_compile_options(${TARGET_NAME} PUBLIC -fprofile-instr-generate -fcoverage-mapping)
+            target_link_options(${TARGET_NAME} PUBLIC -fprofile-instr-generate -fcoverage-mapping)
+        endfunction()
+
+        function(add_test_with_coverage)
+            # TODO: wrap add_test so it does this:
+            #   add_test(${TEST_NAME} ARGS)
+            #   set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${TEST_NAME}.profraw)
+        endfunction()
+
+    elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        find_program(GCOV_PATH NAMES gcov)
+        find_program(LCOV_PATH lcov)
+        find_program(GENHTML_PATH genhtml)
+        mark_as_advanced(FORCE
+            GCOV_PATH
+            LCOV_PATH
+            GENHTML_PATH
+        )
+
+        set(EXCLUDE_REGEX
+            --exclude=/usr/include/*
+            --exclude=*/include/fmt/*
+        )
+
+        add_custom_target(coverage DEPENDS ${COVERAGE_INFO})
+
+        add_custom_command(
+            OUTPUT
+                ${COVERAGE_INFO}
+            COMMAND
+                ${LCOV_PATH}
+                --capture
+                --directory ${PROJECT_BINARY_DIR}
+                --output-file ${COVERAGE_INFO}
+                ${EXCLUDE_REGEX}
+        )
+
+        add_custom_target(htmlcov DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html)
+        add_custom_command(
+            OUTPUT
+                ${PROJECT_BINARY_DIR}/htmlcov/index.html
+            COMMAND
+                ${GENHTML_PATH}
+                --output-directory=${CMAKE_BINARY_DIR}/htmlcov
+                ${COVERAGE_INFO}
+            DEPENDS
+                ${COVERAGE_INFO}
+        )
+
+        add_custom_command(
+            TARGET htmlcov
+            POST_BUILD
+            COMMAND ;
+            COMMENT
+                "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
+        )
+
+        function(target_code_coverage TARGET_NAME)
+            target_compile_options(${TARGET_NAME} PUBLIC -fprofile-arcs -ftest-coverage)
+            target_link_options(${TARGET_NAME} PUBLIC -fprofile-arcs -ftest-coverage)
+        endfunction()
+
+        function(add_test_with_coverage)
+        endfunction()
+
+    else()
+        message(STATUS, "Code coverage for your compiler (${CMAKE_C_COMPILER_ID}) is not supported.")
+    endif()
+
+else()
+
+    function(target_code_coverage TARGET_NAME)
+    endfunction()
+
+    function(add_test_with_coverage)
+    endfunction()
+
+endif()

--- a/cmake/Sanitization.cmake
+++ b/cmake/Sanitization.cmake
@@ -1,0 +1,22 @@
+# LLVM: Sanitization
+
+if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+    option(FPROPS_ADDRESS_SANITIZATION "Build with address sanitizer (requires clang)" NO)
+    option(FPROPS_MEMORY_SANITIZATION "Build with memory sanitizer (requires clang)" NO)
+endif()
+
+function(target_sanitization TARGET_NAME)
+    if (FPROPS_ADDRESS_SANITIZATION)
+        if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+            target_compile_options(${TARGET_NAME} PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+            target_link_options(${TARGET_NAME} PUBLIC -fsanitize=address)
+        endif()
+    endif()
+
+    if (FPROPS_MEMORY_SANITIZATION)
+        if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+            target_compile_options(${TARGET_NAME} PUBLIC -fsanitize=leak -fno-omit-frame-pointer)
+            target_link_options(${TARGET_NAME} PUBLIC -fsanitize=leak)
+        endif()
+    endif()
+endfunction()

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -16,8 +16,8 @@ public:
     /// @param T_c Critical temperature \f$[K]\f$
     Helmholtz(double R, double M, double rho_c, double T_c);
 
-    virtual Props p_T(double p, double T) override;
-    virtual Props v_u(double v, double u) override;
+    Props p_T(double p, double T) override;
+    Props v_u(double v, double u) override;
 
 protected:
     /// Helmholtz free energy

--- a/include/IdealGas.h
+++ b/include/IdealGas.h
@@ -20,8 +20,8 @@ public:
     /// @param k Thermal conductivity \f$[W/(m-K)]\f$
     void set_k(double k);
 
-    virtual Props p_T(double p, double T) override;
-    virtual Props v_u(double v, double u) override;
+    Props p_T(double p, double T) override;
+    Props v_u(double v, double u) override;
 
 protected:
     /// Adiabatic index (ratio of specific heats cp/cv)

--- a/include/Nitrogen.h
+++ b/include/Nitrogen.h
@@ -17,15 +17,15 @@ public:
     Nitrogen();
 
 protected:
-    virtual double alpha(double delta, double tau) override;
-    virtual double dalpha_ddelta(double delta, double tau) override;
-    virtual double dalpha_dtau(double delta, double tau) override;
-    virtual double d2alpha_ddelta2(double delta, double tau) override;
-    virtual double d2alpha_dtau2(double delta, double tau) override;
-    virtual double d2alpha_ddeltatau(double delta, double tau) override;
+    double alpha(double delta, double tau) override;
+    double dalpha_ddelta(double delta, double tau) override;
+    double dalpha_dtau(double delta, double tau) override;
+    double d2alpha_ddelta2(double delta, double tau) override;
+    double d2alpha_dtau2(double delta, double tau) override;
+    double d2alpha_ddeltatau(double delta, double tau) override;
 
-    virtual double mu_from_rho_T(double rho, double T) override;
-    virtual double k_from_rho_T(double rho, double T) override;
+    double mu_from_rho_T(double rho, double T) override;
+    double k_from_rho_T(double rho, double T) override;
 };
 
 } // namespace fprops

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
         Numerics.cpp
         SinglePhaseFluidProperties.cpp
 )
+target_code_coverage(${PROJECT_NAME})
+target_sanitization(${PROJECT_NAME})
 
 set_target_properties(
     ${PROJECT_NAME}

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1,7 +1,7 @@
 #include "Helmholtz.h"
 #include "Numerics.h"
 #include <cmath>
-#include <assert.h>
+#include <cassert>
 
 namespace fprops {
 

--- a/src/IdealGas.cpp
+++ b/src/IdealGas.cpp
@@ -1,7 +1,6 @@
 #include "IdealGas.h"
 #include <cmath>
 #include <assert.h>
-#include "fmt/printf.h"
 
 namespace fprops {
 

--- a/src/Nitrogen.cpp
+++ b/src/Nitrogen.cpp
@@ -62,7 +62,7 @@ static const double N_k[] = { 8.862, 31.11, -73.13, 20.03, -0.7096, 0.2672 };
 static const double t_k[] = { 0.0, 0.03, 0.2, 0.8, 0.6, 1.9 };
 static const unsigned int d_k[] = { 1, 2, 3, 4, 8, 10 };
 static const unsigned int l_k[] = { 0, 0, 1, 2, 2, 2 };
-static const double gamma_k[] = { 0.0, 0.0, 1.0, 1.0, 1.0 };
+static const double gamma_k[] = { 0.0, 0.0, 1.0, 1.0, 1.0, 1.0 };
 
 Nitrogen::Nitrogen() : Helmholtz(R, M, rho_c, T_c) {}
 

--- a/src/Nitrogen.cpp
+++ b/src/Nitrogen.cpp
@@ -6,11 +6,6 @@ namespace fprops {
 
 #define len(a) (sizeof(a) / sizeof(a[0]))
 
-#define R 8.314510
-#define M 28.01348e-3
-#define rho_c 313.299958972
-#define T_c 126.192
-
 // Coefficients for ideal gas component of the Helmholtz free energy
 static const double a[] = { 2.5,          -12.76952708, -0.00784163, -1.934819e-4,
                             -1.247742e-5, 6.678326e-8,  1.012941,    26.65788 };
@@ -64,7 +59,7 @@ static const unsigned int d_k[] = { 1, 2, 3, 4, 8, 10 };
 static const unsigned int l_k[] = { 0, 0, 1, 2, 2, 2 };
 static const double gamma_k[] = { 0.0, 0.0, 1.0, 1.0, 1.0, 1.0 };
 
-Nitrogen::Nitrogen() : Helmholtz(R, M, rho_c, T_c) {}
+Nitrogen::Nitrogen() : Helmholtz(8.314510, 28.01348e-3, 313.299958972, 126.192) {}
 
 double
 Nitrogen::alpha(double delta, double tau)
@@ -204,8 +199,8 @@ Nitrogen::d2alpha_ddeltatau(double delta, double tau)
 double
 Nitrogen::mu_from_rho_T(double rho, double T)
 {
-    const double delta = rho / rho_c;
-    const double tau = T_c / T;
+    const double delta = rho / this->rho_c;
+    const double tau = this->T_c / T;
     const double logTstar = std::log(T / 98.94);
 
     // The dilute gas component
@@ -213,7 +208,7 @@ Nitrogen::mu_from_rho_T(double rho, double T)
     for (unsigned int i = 0; i < len(b_mu); i++)
         logOmega += b_mu[i] * std::pow(logTstar, i);
     const double mu0 =
-        0.0266958 * std::sqrt(1000.0 * M * T) / (0.3656 * 0.3656 * std::exp(logOmega));
+        0.0266958 * std::sqrt(1000.0 * this->M * T) / (0.3656 * 0.3656 * std::exp(logOmega));
 
     // The residual component
     double mur = 0.0;
@@ -228,8 +223,8 @@ Nitrogen::mu_from_rho_T(double rho, double T)
 double
 Nitrogen::k_from_rho_T(double rho, double T)
 {
-    const double delta = rho / rho_c;
-    const double tau = T_c / T;
+    const double delta = rho / this->rho_c;
+    const double tau = this->T_c / T;
 
     // The dilute gas component
     const double lambda0 =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,3 +9,15 @@ add_test(
     NAME fprops-test
     COMMAND ${PROJECT_NAME}
 )
+set_tests_properties(${PROJECT_NAME}
+    PROPERTIES
+        LABELS unit-tests
+)
+
+if(FPROPS_CODE_COVERAGE)
+    set_tests_properties(
+        ${PROJECT_NAME}
+        PROPERTIES
+            ENVIRONMENT LLVM_PROFILE_FILE=${PROJECT_NAME}.profraw
+    )
+endif()

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(${PROJECT_NAME}
     Numerics_test.cpp
     main.cpp
 )
+target_code_coverage(${PROJECT_NAME})
+target_sanitization(${PROJECT_NAME})
 
 target_include_directories(
     ${PROJECT_NAME}
@@ -21,7 +23,3 @@ target_link_libraries(
         gtest_main
         gmock_main
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()


### PR DESCRIPTION
- Fixes suggested by clang-tidy
- Adding code coverage and address sanitization
- Fixing access out of bounds
- Getting rid of macros
- gha: Bump version of clang-format to 14
- Adding codecov to gha:build
