### PR TITLE
cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 include(FetchContent)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 include(${PROJECT_SOURCE_DIR}/cmake/CodeCoverage.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/Sanitization.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,27 +24,28 @@ if (FPROPS_WITH_PYTHON)
     add_subdirectory(python)
 endif()
 
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.11.0
-)
-set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-mark_as_advanced(FORCE
-    BUILD_GMOCK
-    INSTALL_GTEST
-    FETCHCONTENT_SOURCE_DIR_GOOGLETEST
-    FETCHCONTENT_UPDATES_DISCONNECTED_GOOGLETEST
-)
+if (FPROPS_BUILD_TESTS)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG        release-1.11.0
+    )
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    mark_as_advanced(FORCE
+        BUILD_GMOCK
+        INSTALL_GTEST
+        FETCHCONTENT_SOURCE_DIR_GOOGLETEST
+        FETCHCONTENT_UPDATES_DISCONNECTED_GOOGLETEST
+    )
 
-FetchContent_MakeAvailable(googletest)
-mark_as_advanced(FORCE
-    FETCHCONTENT_BASE_DIR
-    FETCHCONTENT_FULLY_DISCONNECTED
-    FETCHCONTENT_QUIET
-    FETCHCONTENT_UPDATES_DISCONNECTED
-)
-
+    FetchContent_MakeAvailable(googletest)
+    mark_as_advanced(FORCE
+        FETCHCONTENT_BASE_DIR
+        FETCHCONTENT_FULLY_DISCONNECTED
+        FETCHCONTENT_QUIET
+        FETCHCONTENT_UPDATES_DISCONNECTED
+    )
+endif()
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/Sanitization.cmake)
 option(FPROPS_WITH_PYTHON "Build python wrapper" YES)
 option(FPROPS_BUILD_TESTS "Build tests" NO)
 
-find_package(fmt REQUIRED)
+find_package(fmt 8.0 REQUIRED)
 if (FPROPS_WITH_PYTHON)
     add_subdirectory(python)
 endif()

--- a/cmake/fpropsConfig.cmake
+++ b/cmake/fpropsConfig.cmake
@@ -1,5 +1,0 @@
-include(CMakeFindDependencyMacro)
-
-find_dependency(fmt REQUIRED)
-
-include("${CMAKE_CURRENT_LIST_DIR}/fpropsTargets.cmake")

--- a/cmake/fpropsConfig.cmake.in
+++ b/cmake/fpropsConfig.cmake.in
@@ -1,0 +1,15 @@
+set(FPROPS_VERSION @PROJECT_VERSION@)
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/fpropsTargets.cmake")
+include(FindPackageHandleStandardArgs)
+
+find_library(FPROPS_LIBRARY NAMES fprops HINTS ${PACKAGE_PREFIX_DIR}/lib NO_DEFAULT_PATH)
+find_path(FPROPS_INCLUDE_DIR SinglePhaseFluidProperties.h HINTS ${PACKAGE_PREFIX_DIR}/include/fprops)
+
+find_package_handle_standard_args(
+    fprops
+    REQUIRED_VARS FPROPS_LIBRARY FPROPS_INCLUDE_DIR
+    VERSION_VAR FPROPS_VERSION
+)

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4...3.18)
 project(pyfprops LANGUAGES CXX)
 
-find_package(pybind11 REQUIRED)
+find_package(pybind11 2.9 REQUIRED)
 
 pybind11_add_module(${PROJECT_NAME} fprops.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,17 @@ target_link_libraries(
         fmt::fmt
 )
 
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/fpropsConfig.cmake.in
+    fpropsConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fprops
+    NO_SET_AND_CHECK_MACRO
+)
+write_basic_package_version_file(fpropsConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
 install(
     TARGETS fprops
     EXPORT fpropsTargets
@@ -54,24 +65,16 @@ install(
     FILES_MATCHING PATTERN "*.h"
 )
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    fpropsConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
-)
-
 install(
     EXPORT fpropsTargets
     FILE fpropsTargets.cmake
     NAMESPACE fprops::
-    DESTINATION lib/cmake/fprops
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fprops
 )
 
 install(
     FILES
-        "${PROJECT_SOURCE_DIR}/cmake/fpropsConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/fpropsConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/fpropsConfigVersion.cmake"
-    DESTINATION
-        lib/cmake/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fprops
 )


### PR DESCRIPTION
- cmake: improving fpropsConfig.cmake
- cmake: do not build gtest if not building tests
- cmake: requiring specific version of fmt
- cmake: requiring specific version of pybind
