### PR TITLE
Fixing install command for the python package

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(
 install(
     TARGETS ${PROJECT_NAME}
     COMPONENT python
-    LIBRARY DESTINATION "${Python3_SITELIB}/pyfprops"
+    LIBRARY DESTINATION "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/pyfprops"
 )


### PR DESCRIPTION
This fixes the problem when building a conda package. The Python3_SITELIB
variable has value from the BUILD environemnt, but we need to be using
HOST environment. This way we use CMAKE_INSTALL_PREFIX which has the right
value.
