### PR TITLE
Refactoring math::pow

### DIFF
--- a/include/fprops/Helmholtz.h
+++ b/include/fprops/Helmholtz.h
@@ -205,7 +205,7 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); ++i)
-                sum += this->n[i] * std::pow(tau, this->t[i]);
+                sum += this->n[i] * math::pow(tau, this->t[i]);
             return sum;
         }
 
@@ -214,7 +214,7 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < n.size(); ++i)
-                sum += this->n[i] * this->t[i] * std::pow(tau, this->t[i] - 1);
+                sum += this->n[i] * this->t[i] * math::pow(tau, this->t[i] - 1);
             return sum;
         }
 
@@ -223,7 +223,7 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); ++i)
-                sum += this->n[i] * this->t[i] * (this->t[i] - 1) * std::pow(tau, this->t[i] - 2);
+                sum += this->n[i] * this->t[i] * (this->t[i] - 1) * math::pow(tau, this->t[i] - 2);
             return sum;
         }
 
@@ -429,7 +429,7 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
-                sum += this->n[i] * std::pow(delta, this->d[i]) * std::pow(tau, this->t[i]);
+                sum += this->n[i] * math::pow(delta, this->d[i]) * math::pow(tau, this->t[i]);
             return sum;
         }
 
@@ -438,8 +438,8 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
-                sum += this->n[i] * this->d[i] * std::pow(delta, this->d[i] - 1) *
-                       std::pow(tau, this->t[i]);
+                sum += this->n[i] * this->d[i] * math::pow(delta, this->d[i] - 1) *
+                       math::pow(tau, this->t[i]);
             return sum;
         }
 
@@ -448,8 +448,8 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
-                sum += this->n[i] * std::pow(delta, this->d[i]) * this->t[i] *
-                       std::pow(tau, this->t[i] - 1);
+                sum += this->n[i] * math::pow(delta, this->d[i]) * this->t[i] *
+                       math::pow(tau, this->t[i] - 1);
             return sum;
         }
 
@@ -459,7 +459,7 @@ protected:
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * this->d[i] * (this->d[i] - 1) *
-                       std::pow(delta, this->d[i] - 2) * std::pow(tau, this->t[i]);
+                       math::pow(delta, this->d[i] - 2) * math::pow(tau, this->t[i]);
             return sum;
         }
 
@@ -468,8 +468,8 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
-                sum += this->n[i] * std::pow(delta, this->d[i]) * this->t[i] * (this->t[i] - 1) *
-                       std::pow(tau, this->t[i] - 2);
+                sum += this->n[i] * math::pow(delta, this->d[i]) * this->t[i] * (this->t[i] - 1) *
+                       math::pow(tau, this->t[i] - 2);
             return sum;
         }
 
@@ -478,8 +478,8 @@ protected:
         {
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
-                sum += this->n[i] * this->d[i] * std::pow(delta, this->d[i] - 1) * this->t[i] *
-                       std::pow(tau, this->t[i] - 1);
+                sum += this->n[i] * this->d[i] * math::pow(delta, this->d[i] - 1) * this->t[i] *
+                       math::pow(tau, this->t[i] - 1);
             return sum;
         }
 

--- a/include/fprops/Helmholtz.h
+++ b/include/fprops/Helmholtz.h
@@ -309,8 +309,8 @@ protected:
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); ++i) {
                 double exp_theta_tau = std::exp(this->theta[i] * tau);
-                sum += this->n[i] * sqr(this->theta[i]) * this->c[i] * this->d[i] * exp_theta_tau /
-                       sqr(this->c[i] + this->d[i] * exp_theta_tau);
+                sum += this->n[i] * math::pow<2>(this->theta[i]) * this->c[i] * this->d[i] *
+                       exp_theta_tau / math::pow<2>(this->c[i] + this->d[i] * exp_theta_tau);
             }
             return sum;
         }
@@ -551,7 +551,7 @@ protected:
                 sum +=
                     this->n[i] * std::pow(delta, this->d[i] - 2) * std::pow(tau, this->t[i]) *
                     std::exp(-std::pow(delta, this->l[i])) *
-                    (sqr(this->l[i]) * std::pow(delta, 2 * this->l[i]) +
+                    (math::pow<2>(this->l[i]) * std::pow(delta, 2 * this->l[i]) +
                      (this->d[i] - 1) * this->d[i] -
                      this->l[i] * (2 * this->d[i] + this->l[i] - 1) * std::pow(delta, this->l[i]));
             return sum;
@@ -623,8 +623,8 @@ protected:
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * std::pow(delta, this->d[i]) * std::pow(tau, this->t[i]) *
-                       std::exp(-this->eta[i] * sqr(delta - this->epsilon[i]) -
-                                this->beta[i] * sqr(tau - this->gamma[i]));
+                       std::exp(-this->eta[i] * math::pow<2>(delta - this->epsilon[i]) -
+                                this->beta[i] * math::pow<2>(tau - this->gamma[i]));
             return sum;
         }
 
@@ -635,8 +635,8 @@ protected:
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * std::pow(delta, this->d[i] - 1) * std::pow(tau, this->t[i]) *
                        (this->d[i] - 2.0 * delta * this->eta[i] * (delta - this->epsilon[i])) *
-                       std::exp(-this->eta[i] * sqr(delta - this->epsilon[i]) -
-                                this->beta[i] * sqr(tau - this->gamma[i]));
+                       std::exp(-this->eta[i] * math::pow<2>(delta - this->epsilon[i]) -
+                                this->beta[i] * math::pow<2>(tau - this->gamma[i]));
             return sum;
         }
 
@@ -647,8 +647,8 @@ protected:
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * std::pow(delta, this->d[i]) * std::pow(tau, this->t[i] - 1) *
                        (2.0 * this->beta[i] * (this->gamma[i] - tau) * tau + this->t[i]) *
-                       std::exp(-this->eta[i] * sqr(delta - this->epsilon[i]) -
-                                this->beta[i] * sqr(tau - this->gamma[i]));
+                       std::exp(-this->eta[i] * math::pow<2>(delta - this->epsilon[i]) -
+                                this->beta[i] * math::pow<2>(tau - this->gamma[i]));
             return sum;
         }
 
@@ -658,12 +658,12 @@ protected:
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * std::pow(delta, this->d[i] - 2) * std::pow(tau, this->t[i]) *
-                       (2 * sqr(delta) * this->eta[i] *
-                            (2 * this->eta[i] * sqr(delta - this->epsilon[i]) - 1) +
-                        sqr(this->d[i]) +
+                       (2 * math::pow<2>(delta) * this->eta[i] *
+                            (2 * this->eta[i] * math::pow<2>(delta - this->epsilon[i]) - 1) +
+                        math::pow<2>(this->d[i]) +
                         this->d[i] * (4 * delta * this->eta[i] * (this->epsilon[i] - delta) - 1)) *
-                       std::exp(-this->eta[i] * sqr(delta - this->epsilon[i]) -
-                                this->beta[i] * sqr(tau - this->gamma[i]));
+                       std::exp(-this->eta[i] * math::pow<2>(delta - this->epsilon[i]) -
+                                this->beta[i] * math::pow<2>(tau - this->gamma[i]));
             return sum;
         }
 
@@ -673,12 +673,12 @@ protected:
             T sum = 0;
             for (std::size_t i = 0; i < this->n.size(); i++)
                 sum += this->n[i] * std::pow(delta, this->d[i]) * std::pow(tau, this->t[i] - 2) *
-                       (2 * this->beta[i] * sqr(tau) *
-                            (2 * this->beta[i] * sqr(this->gamma[i] - tau) - 1) +
-                        sqr(this->t[i]) +
+                       (2 * this->beta[i] * math::pow<2>(tau) *
+                            (2 * this->beta[i] * math::pow<2>(this->gamma[i] - tau) - 1) +
+                        math::pow<2>(this->t[i]) +
                         this->t[i] * (4 * this->beta[i] * (this->gamma[i] - tau) * tau - 1)) *
-                       std::exp(-this->eta[i] * sqr(delta - this->epsilon[i]) -
-                                this->beta[i] * sqr(tau - this->gamma[i]));
+                       std::exp(-this->eta[i] * math::pow<2>(delta - this->epsilon[i]) -
+                                this->beta[i] * math::pow<2>(tau - this->gamma[i]));
             return sum;
         }
 
@@ -691,8 +691,8 @@ protected:
                        std::pow(tau, this->t[i] - 1) *
                        (2. * this->beta[i] * (this->gamma[i] - tau) * tau + this->t[i]) *
                        (2. * delta * this->eta[i] * (this->epsilon[i] - delta) + this->d[i]) *
-                       std::exp(-this->beta[i] * sqr(this->gamma[i] - tau) -
-                                this->eta[i] * sqr(delta - this->epsilon[i]));
+                       std::exp(-this->beta[i] * math::pow<2>(this->gamma[i] - tau) -
+                                this->eta[i] * math::pow<2>(delta - this->epsilon[i]));
             return sum;
         }
 
@@ -837,13 +837,13 @@ protected:
         theta(std::size_t i, T delta, T tau) const
         {
             return (1.0 - tau) +
-                   this->A[i] * std::pow(sqr(delta - 1.0), 1.0 / (2.0 * this->beta[i]));
+                   this->A[i] * std::pow(math::pow<2>(delta - 1.0), 1.0 / (2.0 * this->beta[i]));
         }
 
         T
         dtheta_ddelta(std::size_t i, T delta, T tau) const
         {
-            return this->A[i] * std::pow(sqr(delta - 1), 1. / (2. * this->beta[i])) /
+            return this->A[i] * std::pow(math::pow<2>(delta - 1), 1. / (2. * this->beta[i])) /
                    (this->beta[i] * (delta - 1));
         }
 
@@ -858,14 +858,15 @@ protected:
         {
             return -1 *
                    (this->A[i] * (this->beta[i] - 1) *
-                    std::pow(sqr(delta - 1), 1. / (2 * this->beta[i]) - 1.)) /
-                   (sqr(this->beta[i]));
+                    std::pow(math::pow<2>(delta - 1), 1. / (2 * this->beta[i]) - 1.)) /
+                   (math::pow<2>(this->beta[i]));
         }
 
         T
         DELTA(std::size_t i, T delta, T tau) const
         {
-            return sqr(theta(i, delta, tau)) + this->B[i] * std::pow(sqr(delta - 1.0), this->a[i]);
+            return math::pow<2>(theta(i, delta, tau)) +
+                   this->B[i] * std::pow(math::pow<2>(delta - 1.0), this->a[i]);
         }
 
         T
@@ -884,8 +885,8 @@ protected:
         T
         d2DELTA_ddelta2(std::size_t i, T delta, T tau) const
         {
-            return 2. * (sqr(dtheta_ddelta(i, delta, tau) +
-                             theta(i, delta, tau) * d2theta_ddelta2(i, delta, tau))) +
+            return 2. * (math::pow<2>(dtheta_ddelta(i, delta, tau) +
+                                      theta(i, delta, tau) * d2theta_ddelta2(i, delta, tau))) +
                    2 * this->a[i] * (2 * this->a[i] - 1) * this->B[i] *
                        std::pow(delta - 1, 2 * this->a[i] - 2);
         }
@@ -893,7 +894,7 @@ protected:
         T
         d2DELTA_dtau2(std::size_t i, T delta, T tau) const
         {
-            return 2. * sqr(dtheta_dtau(i, delta, tau));
+            return 2. * math::pow<2>(dtheta_dtau(i, delta, tau));
         }
 
         T
@@ -946,42 +947,48 @@ protected:
         T
         PSI(std::size_t i, T delta, T tau) const
         {
-            return std::exp(-this->C[i] * sqr(delta - 1.0) - this->D[i] * sqr(tau - 1.0));
+            return std::exp(-this->C[i] * math::pow<2>(delta - 1.0) -
+                            this->D[i] * math::pow<2>(tau - 1.0));
         }
 
         T
         dPSI_ddelta(std::size_t i, T delta, T tau) const
         {
             return -2 * this->C[i] * (delta - 1) *
-                   std::exp(-this->C[i] * sqr(delta - 1) - this->D[i] * sqr(tau - 1));
+                   std::exp(-this->C[i] * math::pow<2>(delta - 1) -
+                            this->D[i] * math::pow<2>(tau - 1));
         }
 
         T
         dPSI_dtau(std::size_t i, T delta, T tau) const
         {
             return -2 * this->D[i] * (tau - 1) *
-                   std::exp(-this->C[i] * sqr(delta - 1) - this->D[i] * sqr(tau - 1));
+                   std::exp(-this->C[i] * math::pow<2>(delta - 1) -
+                            this->D[i] * math::pow<2>(tau - 1));
         }
 
         T
         d2PSI_ddelta2(std::size_t i, T delta, T tau) const
         {
-            return 2 * this->C[i] * (2 * this->C[i] * sqr(delta - 1) - 1) *
-                   std::exp(-this->C[i] * sqr(delta - 1) - this->D[i] * sqr(tau - 1));
+            return 2 * this->C[i] * (2 * this->C[i] * math::pow<2>(delta - 1) - 1) *
+                   std::exp(-this->C[i] * math::pow<2>(delta - 1) -
+                            this->D[i] * math::pow<2>(tau - 1));
         }
 
         T
         d2PSI_dtau2(std::size_t i, T delta, T tau) const
         {
-            return 2 * this->D[i] * (2 * this->D[i] * sqr(tau - 1) - 1) *
-                   std::exp(-this->C[i] * sqr(delta - 1) - this->D[i] * sqr(tau - 1));
+            return 2 * this->D[i] * (2 * this->D[i] * math::pow<2>(tau - 1) - 1) *
+                   std::exp(-this->C[i] * math::pow<2>(delta - 1) -
+                            this->D[i] * math::pow<2>(tau - 1));
         }
 
         T
         d2PSI_ddeltatau(std::size_t i, T delta, T tau) const
         {
             return 4. * this->C[i] * (delta - 1) * this->D[i] * (tau - 1) *
-                   std::exp(-this->C[i] * sqr(delta - 1) - this->D[i] * sqr(tau - 1));
+                   std::exp(-this->C[i] * math::pow<2>(delta - 1) -
+                            this->D[i] * math::pow<2>(tau - 1));
         }
 
         std::vector<T> n;

--- a/include/fprops/Numerics.h
+++ b/include/fprops/Numerics.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <stdexcept>
 #include <type_traits>
+#include <cmath>
 
 namespace fprops {
 
@@ -76,6 +77,14 @@ pow(T x, int e)
     }
 
     return neg ? 1.0 / result : result;
+}
+
+/// Alias for covenience, or potentially for better implementation
+template <typename T, typename EXP>
+inline T
+pow(T x, EXP exp)
+{
+    return std::pow(x, exp);
 }
 
 } // namespace math

--- a/include/fprops/Numerics.h
+++ b/include/fprops/Numerics.h
@@ -4,25 +4,57 @@
 #pragma once
 
 #include <functional>
+#include <stdexcept>
+#include <type_traits>
 
 namespace fprops {
 
-inline double
-sqr(double x)
-{
-    return x * x;
-}
-
-inline double
-cb(double x)
-{
-    return x * x * x;
-}
-
 namespace math {
 
+template <int N, typename T>
+struct pow_impl {
+    static inline T
+    value(T x)
+    {
+        if (N % 2)
+            return x * pow_impl<N - 1, T>::value(x);
+        T x_n_half = pow_impl<N / 2, T>::value(x);
+        return x_n_half * x_n_half;
+    }
+};
+
 template <typename T>
-T
+struct pow_impl<1, T> {
+    static inline T
+    value(T x)
+    {
+        return x;
+    }
+};
+
+template <typename T>
+struct pow_impl<0, T> {
+    static inline T
+    value(T)
+    {
+        return 1;
+    }
+};
+
+template <int N, typename T>
+inline T
+pow(T x)
+{
+    return pow_impl<N, T>::value(x);
+}
+
+/// Compute `e` power of `x`
+///
+/// @param x Operand
+/// @param e Exponent (integer)
+/// @return `x` to the power of `e`
+template <typename T>
+inline T
 pow(T x, int e)
 {
     bool neg = false;

--- a/include/fprops/TransportModels.h
+++ b/include/fprops/TransportModels.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include "Numerics.h"
 #include <vector>
-#include <cmath>
 #include <cassert>
 
 namespace fprops {
@@ -39,7 +39,7 @@ public:
     {
         T sum = this->A[0] * eta0;
         for (unsigned int i = 1; i < A.size(); i++)
-            sum += this->A[i] * std::pow(tau, this->t[i]);
+            sum += this->A[i] * math::pow(tau, this->t[i]);
         return sum;
     }
 
@@ -94,7 +94,7 @@ public:
         double log_T_star = std::log(temperature / this->epsilon_over_k);
         double Omega_T_star = 0;
         for (unsigned int i = 0; i < this->b.size(); i++)
-            Omega_T_star += this->b[i] * std::pow(log_T_star, i);
+            Omega_T_star += this->b[i] * math::pow(log_T_star, i);
         Omega_T_star = std::exp(Omega_T_star);
         return this->C * std::sqrt(1000.0 * this->M * temperature) /
                (this->sigma * this->sigma * Omega_T_star);
@@ -146,8 +146,8 @@ public:
     {
         double sum = 0.0;
         for (unsigned int i = 0; i < n.size(); i++)
-            sum += this->n[i] * std::pow(tau, this->t[i]) * std::pow(delta, this->d[i]) *
-                   std::exp(-this->gamma[i] * std::pow(delta, this->l[i]));
+            sum += this->n[i] * math::pow(tau, this->t[i]) * math::pow(delta, this->d[i]) *
+                   std::exp(-this->gamma[i] * math::pow(delta, this->l[i]));
         return sum;
     }
 

--- a/src/Helium.cpp
+++ b/src/Helium.cpp
@@ -148,14 +148,14 @@ Helium::mu_from_rho_T(double rho, double T) const
         x = std::log(300.0);
 
     // Evaluate the terms B, C, D
-    double B =
-        -47.5295259 / x + 87.6799309 - 42.0741589 * x + 8.33128289 * sqr(x) - 0.589252385 * cb(x);
-    double C =
-        547.309267 / x - 904.870586 + 431.404928 * x - 81.4504854 * sqr(x) + 5.37008433 * cb(x);
-    double D =
-        -1684.39324 / x + 3331.08630 - 1632.19172 * x + 308.804413 * sqr(x) - 20.2936367 * cb(x);
-    double eta_0_slash =
-        -0.135311743 / x + 1.00347841 + 1.20654649 * x - 0.149564551 * sqr(x) + 0.012520841 * cb(x);
+    double B = -47.5295259 / x + 87.6799309 - 42.0741589 * x + 8.33128289 * math::pow<2>(x) -
+               0.589252385 * math::pow<3>(x);
+    double C = 547.309267 / x - 904.870586 + 431.404928 * x - 81.4504854 * math::pow<2>(x) +
+               5.37008433 * math::pow<3>(x);
+    double D = -1684.39324 / x + 3331.08630 - 1632.19172 * x + 308.804413 * math::pow<2>(x) -
+               20.2936367 * math::pow<3>(x);
+    double eta_0_slash = -0.135311743 / x + 1.00347841 + 1.20654649 * x -
+                         0.149564551 * math::pow<2>(x) + 0.012520841 * math::pow<3>(x);
     double eta_E_slash = rho * B + rho * rho * C + rho * rho * rho * D;
 
     double eta;

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -259,7 +259,7 @@ Helmholtz::sound_speed(double T,
                        double d2a_dt2) const
 {
     const double n = 2.0 * delta * da_dd + delta * delta * d2a_dd2 -
-                     sqr(delta * da_dd - delta * tau * d2a_ddt) / (tau * tau * d2a_dt2);
+                     math::pow<2>(delta * da_dd - delta * tau * d2a_ddt) / (tau * tau * d2a_dt2);
     return std::sqrt(this->R * T * n / this->M);
 }
 
@@ -278,7 +278,7 @@ Helmholtz::heat_capacity_isobaric(double delta,
                                   double d2a_ddt) const
 {
     return this->R *
-           (-tau * tau * d2a_dt2 + sqr(delta * da_dd - delta * tau * d2a_ddt) /
+           (-tau * tau * d2a_dt2 + math::pow<2>(delta * da_dd - delta * tau * d2a_ddt) /
                                        (2.0 * delta * da_dd + delta * delta * d2a_dd2)) /
            this->M;
 }

--- a/test/src/Numerics_test.cpp
+++ b/test/src/Numerics_test.cpp
@@ -4,14 +4,14 @@
 
 using namespace fprops;
 
-TEST(NumericsTest, sqr)
+TEST(NumericsTest, pow2)
 {
-    EXPECT_DOUBLE_EQ(sqr(2.), 4.);
+    EXPECT_DOUBLE_EQ(math::pow<2>(2.), 4.);
 }
 
-TEST(NumericsTest, cb)
+TEST(NumericsTest, pow3)
 {
-    EXPECT_DOUBLE_EQ(cb(2.), 8.);
+    EXPECT_DOUBLE_EQ(math::pow<3>(2.), 8.);
 }
 
 TEST(NumericsTest, pow)


### PR DESCRIPTION
- Using math::pow<N> instead of `sqr` and `cb`
- Wrapping std::pow into math::pow
